### PR TITLE
Fix warning with -DSKIP_usd=true

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -3,7 +3,8 @@
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DSKIP_usd=true
 
 override_dh_auto_test-arch:
 	LD_LIBRARY_PATH=$(CURDIR)/obj-$(DEB_HOST_GNU_TYPE)/src LC_ALL=C dh_auto_test


### PR DESCRIPTION
Similar to https://github.com/ignition-release/sdformat12-release/pull/4

Should fix the unstable nightlies

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat13-debbuilder&build=242)](https://build.osrfoundation.org/job/sdformat13-debbuilder/242/) https://build.osrfoundation.org/job/sdformat13-debbuilder/242/

with this branch:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat13-debbuilder&build=244)](https://build.osrfoundation.org/job/sdformat13-debbuilder/244/) https://build.osrfoundation.org/job/sdformat13-debbuilder/244/
