### PR TITLE
Fix dependencies for python build

### DIFF
--- a/focal/debian/control
+++ b/focal/debian/control
@@ -5,7 +5,7 @@ Section: science
 Priority: optional
 Build-Depends: cmake,
                debhelper (>= 9),
-               dh-python3,
+               dh-python,
                libtinyxml2-dev,
                doxygen,
                texlive-base,
@@ -107,7 +107,7 @@ Description: Simulation Description Format (SDF) parser - SDF files
  or dynamic objects, and articulated robots with various sensors, and acutators.
  The format of SDF is also described by XML, which facilitates updates and
  allows conversion from previous versions. A parser is also contained within
- this package that reads SDF files and returns a C interface.
+ this package that reads SDF files and returns a C++ interface.
  .
  This package contains the Python bindings for SDFormat
 

--- a/focal/debian/control
+++ b/focal/debian/control
@@ -98,6 +98,7 @@ Package: python3-sdformat13
 Architecture: any
 Depends: ${misc:Depends},
          python3-ignition-math7,
+         libsdformat13 (= ${binary:Version}),
          ${python3:Depends}
 Enhances: libsdformat13
 Description: Simulation Description Format (SDF) parser - SDF files


### PR DESCRIPTION
`dh-python3` doesn't exist in `focal`, but `dh-python` does both in focal and jammy.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=sdformat13-debbuilder&build=256)](https://build.osrfoundation.org/job/sdformat13-debbuilder/256/)